### PR TITLE
New event fixes

### DIFF
--- a/app/src/main/java/com/example/petcare/data/local/hive/HiveCacheManagement.kt
+++ b/app/src/main/java/com/example/petcare/data/local/hive/HiveCacheManagement.kt
@@ -208,6 +208,26 @@ class HiveCacheManager(context: Context) {
         eventId: String
     ) = delete("hidden_event_docs_${petId}_$eventId")
 
+    // ── Local-to-server event ID redirect (no TTL: survives until next install) ──
+    // Written by SyncWorker when a local_ev_ event is created on the server.
+    // Read by EventRepository.getEvent() so stale nav args still resolve correctly.
+    fun putLocalEventIdRedirect(localId: String, serverId: String) =
+        put("local_ev_redirect_$localId", serverId)
+    fun getLocalEventIdRedirect(localId: String): String? =
+        get("local_ev_redirect_$localId")
+
+    // ── Pending event document deletes (no TTL: offline queue) ──────────
+    // Stored as JSON array of "petId|eventId|documentId" strings
+    fun putPendingEventDocumentDeletes(json: String) = put("pending_event_doc_deletes", json)
+    fun getPendingEventDocumentDeletes(): String? = get("pending_event_doc_deletes")
+    fun invalidatePendingEventDocumentDeletes() = delete("pending_event_doc_deletes")
+
+    // ── Pending vaccination document deletes (no TTL: offline queue) ─────
+    // Stored as JSON array of "petId|vaccinationId|documentId" strings
+    fun putPendingVaxDocumentDeletes(json: String) = put("pending_vax_doc_deletes", json)
+    fun getPendingVaxDocumentDeletes(): String? = get("pending_vax_doc_deletes")
+    fun invalidatePendingVaxDocumentDeletes() = delete("pending_vax_doc_deletes")
+
     // ── Vacunas catálogo (TTL: 12 horas) ─────────────────────────────────
 
     fun putVaccineCatalog(json: String) =

--- a/app/src/main/java/com/example/petcare/data/repository/EventRepository.kt
+++ b/app/src/main/java/com/example/petcare/data/repository/EventRepository.kt
@@ -190,10 +190,14 @@ class EventRepository(
         return runCatching {
             val event = if (isOnline()) {
                 val response = api.getEvent(eventId)
-                if (!response.isSuccessful) error("Not found: ${response.code()}")
-                val remote = response.body() ?: error("Empty event body")
-                eventDao.upsert(remote.toEntity())
-                remote
+                if (response.isSuccessful) {
+                    val remote = response.body() ?: error("Empty event body")
+                    eventDao.upsert(remote.toEntity())
+                    remote
+                } else {
+                    // Server failed — fall back to Room (handles local_ev_ IDs and sync race conditions)
+                    eventDao.getById(eventId)?.toEvent() ?: error("Not found: ${response.code()}")
+                }
             } else {
                 eventDao.getById(eventId)?.toEvent() ?: error("Not found offline")
             }
@@ -462,6 +466,10 @@ class EventRepository(
             hive.invalidatePendingEventDocuments(petId, eventId)
         } else {
             hive.putPendingEventDocuments(petId, eventId, gson.toJson(remaining))
+        }
+        if (synced > 0) {
+            invalidateBothCaches(petId, eventId)
+            Log.d("DOC_UPLOAD", "Invalidated event caches after pending document sync petId=$petId synced=$synced")
         }
         synced
     }

--- a/app/src/main/java/com/example/petcare/data/repository/EventRepository.kt
+++ b/app/src/main/java/com/example/petcare/data/repository/EventRepository.kt
@@ -186,22 +186,31 @@ class EventRepository(
     }
 
     suspend fun getEvent(eventId: String): Result<Event> {
-        lru.getEvent(eventId)?.let { return Result.success(it) }
+        // Follow any local→server ID redirect written by SyncWorker when a local_ev_ event
+        // was created on the server. This handles the race where the list still shows the
+        // old local ID but the Room entity has already been replaced with the server ID.
+        val resolvedId = if (eventId.startsWith("local_ev_")) {
+            hive.getLocalEventIdRedirect(eventId) ?: eventId
+        } else {
+            eventId
+        }
+
+        lru.getEvent(resolvedId)?.let { return Result.success(it) }
         return runCatching {
             val event = if (isOnline()) {
-                val response = api.getEvent(eventId)
+                val response = api.getEvent(resolvedId)
                 if (response.isSuccessful) {
                     val remote = response.body() ?: error("Empty event body")
                     eventDao.upsert(remote.toEntity())
                     remote
                 } else {
                     // Server failed — fall back to Room (handles local_ev_ IDs and sync race conditions)
-                    eventDao.getById(eventId)?.toEvent() ?: error("Not found: ${response.code()}")
+                    eventDao.getById(resolvedId)?.toEvent() ?: error("Not found: ${response.code()}")
                 }
             } else {
-                eventDao.getById(eventId)?.toEvent() ?: error("Not found offline")
+                eventDao.getById(resolvedId)?.toEvent() ?: error("Not found offline")
             }
-            lru.putEvent(eventId, event)
+            lru.putEvent(resolvedId, event)
             event
         }
     }
@@ -311,11 +320,8 @@ class EventRepository(
         event
     }
 
-    suspend fun deleteEventDocument(eventId: String, documentId: String): Result<Event> {
-        if (!isOnline()) return Result.failure(
-            Exception("No internet connection. Document delete will be available when you're back online.")
-        )
-        return runCatching {
+    suspend fun deleteEventDocument(eventId: String, documentId: String): Result<Event> =
+        runCatching {
             val response = api.deleteEventDocument(eventId, documentId)
             if (!response.isSuccessful) error("Delete document failed: ${response.code()}")
             val event = response.body() ?: error("Empty response after document delete")
@@ -324,6 +330,57 @@ class EventRepository(
             lru.putEvent(eventId, event)
             event
         }
+
+    fun queueEventDocumentDelete(petId: String, eventId: String, documentId: String) {
+        val existing = getPendingEventDocumentDeletesList()
+        val entry = "$petId|$eventId|$documentId"
+        if (entry !in existing) {
+            hive.putPendingEventDocumentDeletes(gson.toJson(existing + entry))
+            enqueueSyncWork()
+        }
+    }
+
+    private fun getPendingEventDocumentDeletesList(): List<String> {
+        val json = hive.getPendingEventDocumentDeletes() ?: return emptyList()
+        return runCatching {
+            gson.fromJson(json, Array<String>::class.java).toList()
+        }.getOrElse { emptyList() }
+    }
+
+    suspend fun syncPendingEventDocumentDeletes(petId: String, eventId: String) {
+        if (!isOnline()) return
+        val allPending = getPendingEventDocumentDeletesList().toMutableList()
+        val prefix = "$petId|$eventId|"
+        val toProcess = allPending.filter { it.startsWith(prefix) }
+        if (toProcess.isEmpty()) return
+        var synced = 0
+        toProcess.forEach { entry ->
+            val docId = entry.removePrefix(prefix)
+            runCatching {
+                val response = api.deleteEventDocument(eventId, docId)
+                if (response.isSuccessful || response.code() == 204 || response.code() == 404) {
+                    allPending.remove(entry)
+                    synced++
+                    Log.d("DOC_DELETE", "Synced pending event doc delete eventId=$eventId docId=$docId")
+                }
+            }.onFailure { Log.e("DOC_DELETE", "Pending event doc delete sync failed: ${it.message}", it) }
+        }
+        if (allPending.isEmpty()) hive.invalidatePendingEventDocumentDeletes()
+        else hive.putPendingEventDocumentDeletes(gson.toJson(allPending))
+        if (synced > 0) invalidateBothCaches(petId, eventId)
+    }
+
+    suspend fun syncHiddenEventDocumentDeletes(petId: String, eventId: String) {
+        if (!isOnline()) return
+        val hiddenKeys = getHiddenEventDocumentKeys(petId, eventId)
+        if (hiddenKeys.isEmpty()) return
+        hiddenKeys.forEach { key ->
+            val parts = key.split("|", limit = 2)
+            val fileName = parts.getOrNull(0) ?: return@forEach
+            val fileUri  = parts.getOrNull(1)?.takeIf { it.isNotBlank() }
+            deleteEventDocumentByContent(eventId, fileName, fileUri)
+        }
+        clearHiddenEventDocuments(petId, eventId)
     }
 
     suspend fun deleteEventDocumentByContent(
@@ -521,6 +578,38 @@ class EventRepository(
 
     fun clearHiddenEventDocuments(petId: String, eventId: String) {
         hive.invalidateHiddenEventDocuments(petId, eventId)
+    }
+
+    /**
+     * Filters out docs that were deleted offline (queued for server sync or hidden locally).
+     * Call this whenever building the attachment list from cached/Room data so deleted docs
+     * don't reappear when the user navigates back and the LRU/Room cache still has them.
+     */
+    fun filterLocallyDeletedEventDocs(
+        petId: String,
+        eventId: String,
+        docs: List<com.example.petcare.data.model.AttachedDocument>
+    ): List<com.example.petcare.data.model.AttachedDocument> {
+        val pendingDeleteIds = getPendingEventDocumentDeletesList()
+            .filter { it.startsWith("$petId|$eventId|") }
+            .map { it.removePrefix("$petId|$eventId|") }
+            .toSet()
+
+        val hiddenKeys = getHiddenEventDocumentKeys(petId, eventId)
+
+        return docs
+            .filter { doc ->
+                val docId = (doc.documentId ?: doc.id).orEmpty()
+                docId.isBlank() || docId !in pendingDeleteIds
+            }
+            .filter { doc ->
+                hiddenKeys.none { key ->
+                    val parts = key.split("|", limit = 2)
+                    val hiddenName = parts.getOrNull(0) ?: return@none false
+                    val hiddenUri  = parts.getOrNull(1)?.takeIf { it.isNotBlank() }
+                    doc.fileName == hiddenName || (hiddenUri != null && doc.fileUri == hiddenUri)
+                }
+            }
     }
 
     fun invalidateEventLru(eventId: String) {

--- a/app/src/main/java/com/example/petcare/data/repository/PetRepository.kt
+++ b/app/src/main/java/com/example/petcare/data/repository/PetRepository.kt
@@ -386,6 +386,65 @@ class PetRepository(
         pet
     }
 
+    fun queueVaccinationDocumentDelete(petId: String, vaccinationId: String, documentId: String) {
+        val existing = getPendingVaxDocumentDeletesList()
+        val entry = "$petId|$vaccinationId|$documentId"
+        if (entry !in existing) {
+            hive.putPendingVaxDocumentDeletes(Gson().toJson(existing + entry))
+            enqueueSyncWork()
+        }
+    }
+
+    private fun getPendingVaxDocumentDeletesList(): List<String> {
+        val json = hive.getPendingVaxDocumentDeletes() ?: return emptyList()
+        return runCatching {
+            Gson().fromJson(json, Array<String>::class.java).toList()
+        }.getOrElse { emptyList() }
+    }
+
+    /**
+     * Filters out vax docs that were deleted offline (queued for server sync).
+     * Prevents deleted docs from reappearing when LRU/Room cache still holds the old pet data.
+     */
+    fun filterLocallyDeletedVaxDocs(
+        petId: String,
+        vaccinationId: String,
+        docs: List<com.example.petcare.data.model.AttachedDocument>
+    ): List<com.example.petcare.data.model.AttachedDocument> {
+        val pendingDeleteIds = getPendingVaxDocumentDeletesList()
+            .filter { it.startsWith("$petId|$vaccinationId|") }
+            .map { it.removePrefix("$petId|$vaccinationId|") }
+            .toSet()
+
+        return docs.filter { doc ->
+            val docId = (doc.documentId ?: doc.id).orEmpty()
+            docId.isBlank() || docId !in pendingDeleteIds
+        }
+    }
+
+    suspend fun syncPendingVaxDocumentDeletes(petId: String, vaccinationId: String) {
+        if (!isOnline(context)) return
+        val allPending = getPendingVaxDocumentDeletesList().toMutableList()
+        val prefix = "$petId|$vaccinationId|"
+        val toProcess = allPending.filter { it.startsWith(prefix) }
+        if (toProcess.isEmpty()) return
+        var synced = 0
+        toProcess.forEach { entry ->
+            val docId = entry.removePrefix(prefix)
+            runCatching {
+                val response = api.deleteVaccinationDocument(petId, vaccinationId, docId)
+                if (response.isSuccessful || response.code() == 404) {
+                    allPending.remove(entry)
+                    synced++
+                    Log.d("DOC_DELETE", "Synced pending vax doc delete vaccinationId=$vaccinationId docId=$docId")
+                }
+            }.onFailure { Log.e("DOC_DELETE", "Pending vax doc delete sync failed: ${it.message}", it) }
+        }
+        if (allPending.isEmpty()) hive.invalidatePendingVaxDocumentDeletes()
+        else hive.putPendingVaxDocumentDeletes(Gson().toJson(allPending))
+        if (synced > 0) invalidateVaccinationCache(petId)
+    }
+
     suspend fun queueVaccinationDocument(
         sourceUri: Uri,
         petId: String,
@@ -432,6 +491,17 @@ class PetRepository(
             Log.e("DOC_UPLOAD", "Failed to parse pending vaccination documents: ${it.message}", it)
             emptyList()
         }
+    }
+
+    fun removePendingVaccinationDocument(petId: String, vaccinationId: String, pendingDocId: String) {
+        val all = getPendingVaccinationDocuments(petId, vaccinationId)
+        val toRemove = all.find { it.id == pendingDocId }
+        val remaining = all.filter { it.id != pendingDocId }
+        toRemove?.localUri?.let { uri ->
+            runCatching { File(Uri.parse(uri).path ?: return@runCatching).delete() }
+        }
+        if (remaining.isEmpty()) hive.invalidatePendingVaccinationDocuments(petId, vaccinationId)
+        else hive.putPendingVaccinationDocuments(petId, vaccinationId, Gson().toJson(remaining))
     }
 
     suspend fun syncPendingVaccinationDocuments(

--- a/app/src/main/java/com/example/petcare/data/repository/WeightLogRepository.kt
+++ b/app/src/main/java/com/example/petcare/data/repository/WeightLogRepository.kt
@@ -76,6 +76,22 @@ class WeightLogRepository(
                 val log = response.body() ?: error("Failed to save weight log")
                 weightLogDao.insert(log.toEntity())
                 log
+            }.recoverCatching {
+                val mutationId = request.clientMutationId ?: "weight_${System.currentTimeMillis()}"
+                val tempId = "local_weight_$mutationId"
+                val entity = WeightLogEntity(
+                    id = tempId,
+                    petId = petId,
+                    ownerId = uid,
+                    weight = request.weight,
+                    loggedAt = request.loggedAt,
+                    clientMutationId = mutationId,
+                    pendingSync = true,
+                    pendingDelete = false
+                )
+                weightLogDao.insert(entity)
+                enqueueSyncWork()
+                entity.toWeightLog()
             }
         } else {
             runCatching {

--- a/app/src/main/java/com/example/petcare/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/example/petcare/data/worker/SyncWorker.kt
@@ -79,6 +79,7 @@ class SyncWorker(
                     syncPendingVaccinationUpdates(db, api)
                     syncPendingVaccinationDeletes(db, api)
                     syncPendingVaccinationDocuments(api)
+                    syncPendingVaxDocumentDeletes(api)
                     android.util.Log.d("VAX_SYNC", "vaccination-sync coroutine finished thread=${Thread.currentThread().name}")
                 }
                 launch(Dispatchers.IO + CoroutineName("events-sync")) {
@@ -87,6 +88,7 @@ class SyncWorker(
                     syncPendingEventUpdates(db, api)
                     syncPendingEventDeletes(db, api)
                     syncPendingEventDocuments(api)
+                    syncPendingEventDocumentDeletes(api)
                     android.util.Log.d("EVENT_SYNC", "event-sync coroutine finished thread=${Thread.currentThread().name}")
                 }
                 launch(Dispatchers.IO + CoroutineName("weight-sync")) {
@@ -577,6 +579,8 @@ class SyncWorker(
                     deleteLocalPendingDocument(pending.localUri)
                     com.example.petcare.data.repository.RepositoryProvider.eventRepository
                         .invalidateLruForPet(pending.petId)
+                    com.example.petcare.data.repository.RepositoryProvider.eventRepository
+                        .invalidateEventLru(pending.eventId)
                     android.util.Log.d("EVENT_DOC_UPLOAD", "Worker synced pending event document id=${pending.id}")
                 } catch (e: Exception) {
                     android.util.Log.e("EVENT_DOC_UPLOAD", "Worker pending event document sync failed id=${pending.id}: ${e.message}", e)
@@ -589,6 +593,68 @@ class SyncWorker(
                 hive.putPendingEventDocumentsByKey(key, gson.toJson(remaining))
             }
         }
+    }
+
+    private suspend fun syncPendingEventDocumentDeletes(api: ApiService) {
+        val hive = HiveCacheManager(applicationContext)
+        val gson = Gson()
+        val json = hive.getPendingEventDocumentDeletes() ?: return
+        val pending = runCatching {
+            gson.fromJson(json, Array<String>::class.java).toList()
+        }.getOrElse {
+            android.util.Log.e("DOC_DELETE", "Worker failed to parse pending event doc deletes: ${it.message}", it)
+            return
+        }
+        val remaining = pending.toMutableList()
+        pending.forEach { entry ->
+            val parts = entry.split("|")
+            if (parts.size < 3) { remaining.remove(entry); return@forEach }
+            val (petId, eventId, docId) = parts
+            runCatching {
+                val response = api.deleteEventDocument(eventId, docId)
+                if (response.isSuccessful || response.code() == 204 || response.code() == 404) {
+                    remaining.remove(entry)
+                    com.example.petcare.data.repository.RepositoryProvider.eventRepository
+                        .invalidateLruForPet(petId)
+                    android.util.Log.d("DOC_DELETE", "Worker synced event doc delete eventId=$eventId docId=$docId")
+                }
+            }.onFailure {
+                android.util.Log.e("DOC_DELETE", "Worker event doc delete failed eventId=$eventId docId=$docId: ${it.message}", it)
+            }
+        }
+        if (remaining.isEmpty()) hive.invalidatePendingEventDocumentDeletes()
+        else hive.putPendingEventDocumentDeletes(gson.toJson(remaining))
+    }
+
+    private suspend fun syncPendingVaxDocumentDeletes(api: ApiService) {
+        val hive = HiveCacheManager(applicationContext)
+        val gson = Gson()
+        val json = hive.getPendingVaxDocumentDeletes() ?: return
+        val pending = runCatching {
+            gson.fromJson(json, Array<String>::class.java).toList()
+        }.getOrElse {
+            android.util.Log.e("DOC_DELETE", "Worker failed to parse pending vax doc deletes: ${it.message}", it)
+            return
+        }
+        val remaining = pending.toMutableList()
+        pending.forEach { entry ->
+            val parts = entry.split("|")
+            if (parts.size < 3) { remaining.remove(entry); return@forEach }
+            val (petId, vaccinationId, docId) = parts
+            runCatching {
+                val response = api.deleteVaccinationDocument(petId, vaccinationId, docId)
+                if (response.isSuccessful || response.code() == 404) {
+                    remaining.remove(entry)
+                    com.example.petcare.data.repository.RepositoryProvider.petRepository
+                        .invalidatePetLru(petId)
+                    android.util.Log.d("DOC_DELETE", "Worker synced vax doc delete vaccinationId=$vaccinationId docId=$docId")
+                }
+            }.onFailure {
+                android.util.Log.e("DOC_DELETE", "Worker vax doc delete failed vaccinationId=$vaccinationId docId=$docId: ${it.message}", it)
+            }
+        }
+        if (remaining.isEmpty()) hive.invalidatePendingVaxDocumentDeletes()
+        else hive.putPendingVaxDocumentDeletes(gson.toJson(remaining))
     }
 
     private fun movePendingDocumentsToServerPet(
@@ -663,6 +729,9 @@ class SyncWorker(
                     )
                 }
 
+                // Store redirect BEFORE deleting the old entity so any concurrent
+                // getEvent("local_ev_xxx") call can follow it to the server ID.
+                HiveCacheManager(applicationContext).putLocalEventIdRedirect(entity.id, created.id)
                 db.eventDao().deleteById(entity.id)
                 db.eventDao().upsert(createdEntity)
 

--- a/app/src/main/java/com/example/petcare/ui/screens/addEventForm/AddEventViewModel.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/addEventForm/AddEventViewModel.kt
@@ -27,6 +27,8 @@ import com.example.petcare.util.sanitizeForEditing
 import com.example.petcare.util.trimToNullIfBlank
 import com.example.petcare.util.validateCommittedInput
 import android.widget.Toast
+import com.google.firebase.Firebase
+import com.google.firebase.storage.storage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,6 +36,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.UUID
@@ -251,6 +254,18 @@ class AddEventViewModel(application: Application) : AndroidViewModel(application
             stagedDocuments = _state.value.stagedDocuments.filter { it != doc },
             error = null
         )
+        val url = doc.downloadUrl ?: return
+        viewModelScope.launch(Dispatchers.IO) {
+            when {
+                url.startsWith("https") -> runCatching {
+                    Firebase.storage.getReferenceFromUrl(url).delete().await()
+                }
+                url.startsWith("file:") -> runCatching {
+                    val path = Uri.parse(url).path ?: return@runCatching
+                    File(path).delete()
+                }
+            }
+        }
     }
 
     // ── Submit ────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/example/petcare/ui/screens/addEventForm/AddEventViewModel.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/addEventForm/AddEventViewModel.kt
@@ -26,6 +26,7 @@ import com.example.petcare.util.normalizeForCommit
 import com.example.petcare.util.sanitizeForEditing
 import com.example.petcare.util.trimToNullIfBlank
 import com.example.petcare.util.validateCommittedInput
+import android.widget.Toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -127,7 +128,7 @@ class AddEventViewModel(application: Application) : AndroidViewModel(application
         )
         Log.d(TAG, "Queued event staging document petId=$petId stagingId=$stagingId fileName=$fileName mimeType=$mimeType")
 
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.Default) {
             Log.d(TAG, "Event staging coroutine started thread=${Thread.currentThread().name}")
             try {
                 if (!isOnline(context)) {
@@ -149,7 +150,7 @@ class AddEventViewModel(application: Application) : AndroidViewModel(application
                     return@launch
                 }
 
-                val prepared = async(Dispatchers.IO) {
+                val prepared = async(Dispatchers.Default) {
                     PicassoImageCompressor.prepareImageIfNeeded(context, uri, mimeType, fileName)
                 }.await()
                 Log.d(TAG, "Prepared event staging document original=$fileName prepared=${prepared.fileName} mimeType=${prepared.mimeType}")
@@ -172,6 +173,7 @@ class AddEventViewModel(application: Application) : AndroidViewModel(application
                                         } else it
                                     }
                                 )
+                                Toast.makeText(getApplication(), "Attachment uploaded successfully", Toast.LENGTH_SHORT).show()
                             }
                         },
                         onFailure = { e ->
@@ -283,12 +285,6 @@ class AddEventViewModel(application: Application) : AndroidViewModel(application
             _state.value = s.copy(error = firstError)
             return
         }
-        if (s.stagedDocuments.any { it.isUploading }) {
-            Log.d(TAG, "submit blocked waitingForUploads count=${s.stagedDocuments.count { it.isUploading }}")
-            _state.value = s.copy(error = "Please wait for documents to finish uploading")
-            return
-        }
-
         viewModelScope.launch {
             Log.d(TAG, "submit start petId=${s.petId} stagedDocs=${s.stagedDocuments.size}")
             _state.value = s.copy(isLoading = true, error = null)
@@ -315,7 +311,8 @@ class AddEventViewModel(application: Application) : AndroidViewModel(application
                     // Registrar documentos staged en el backend
                     val successfulDocs = s.stagedDocuments
                         .filter { it.downloadUrl != null && it.error == null }
-                    Log.d(TAG, "submit add event success petId=${s.petId} eventId=${event.id} stagedDocs=${successfulDocs.size}")
+                    val stillUploadingDocs = s.stagedDocuments.filter { it.isUploading }
+                    Log.d(TAG, "submit add event success petId=${s.petId} eventId=${event.id} stagedDocs=${successfulDocs.size} stillUploading=${stillUploadingDocs.size}")
 
                     successfulDocs.forEach { doc ->
                         val localUri = doc.downloadUrl.orEmpty()
@@ -348,6 +345,20 @@ class AddEventViewModel(application: Application) : AndroidViewModel(application
                                 }
                             )
                         }
+                    }
+
+                    // Queue still-uploading docs as pending so they sync when the event is opened
+                    stillUploadingDocs.forEach { doc ->
+                        RepositoryProvider.eventRepository.queueEventDocument(
+                            sourceUri = doc.uri,
+                            petId = s.petId,
+                            eventId = event.id,
+                            fileName = doc.fileName,
+                            mimeType = doc.mimeType
+                        ).fold(
+                            onSuccess = { Log.d(TAG, "submit queued in-flight event document fileName=${doc.fileName} eventId=${event.id}") },
+                            onFailure = { Log.e(TAG, "submit queue in-flight event document failed fileName=${doc.fileName}: ${it.message}", it) }
+                        )
                     }
 
                     saveEventLocallyAndScheduleReminder(event, s.petId)

--- a/app/src/main/java/com/example/petcare/ui/screens/addPetForm/AddPetViewModel.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/addPetForm/AddPetViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.viewModelScope
 import com.example.petcare.data.analytics.FeatureExecutionTracker
 import com.example.petcare.data.model.CreatePetRequest
+import com.example.petcare.data.model.CreateWeightLogRequest
 import com.example.petcare.data.repository.RepositoryProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -138,6 +139,16 @@ class AddPetViewModel(application: Application) : AndroidViewModel(application) 
             }.fold(
                 onSuccess = { pet ->
                     _state.value = _state.value.copy(isLoading = false)
+                    val weight = normalizeForCommit(s.weight, InputFieldPolicy.DECIMAL).trimToNullIfBlank()?.toDoubleOrNull()
+                    if (weight != null) {
+                        viewModelScope.launch {
+                            val today = java.time.LocalDate.now().toString() + "T00:00:00Z"
+                            RepositoryProvider.weightLogRepository.createWeightLog(
+                                pet.id,
+                                CreateWeightLogRequest(weight = weight, loggedAt = today)
+                            )
+                        }
+                    }
                     onSuccess(pet)
                 },
                 onFailure = { e ->

--- a/app/src/main/java/com/example/petcare/ui/screens/addVaccineForm/AddVaccineViewModel.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/addVaccineForm/AddVaccineViewModel.kt
@@ -20,12 +20,15 @@ import com.example.petcare.util.normalizeForCommit
 import com.example.petcare.util.sanitizeForEditing
 import com.example.petcare.util.validateCommittedInput
 import android.widget.Toast
+import com.google.firebase.Firebase
+import com.google.firebase.storage.storage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.time.LocalDate
@@ -252,6 +255,18 @@ class AddVaccineViewModel : ViewModel() {
         _state.value = _state.value.copy(
             stagedDocuments = _state.value.stagedDocuments.filter { it != doc }
         )
+        val url = doc.downloadUrl ?: return
+        viewModelScope.launch(Dispatchers.IO) {
+            when {
+                url.startsWith("https") -> runCatching {
+                    Firebase.storage.getReferenceFromUrl(url).delete().await()
+                }
+                url.startsWith("file:") -> runCatching {
+                    val path = Uri.parse(url).path ?: return@runCatching
+                    File(path).delete()
+                }
+            }
+        }
     }
 
     // ── Submit ────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/example/petcare/ui/screens/addVaccineForm/AddVaccineViewModel.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/addVaccineForm/AddVaccineViewModel.kt
@@ -19,6 +19,7 @@ import com.example.petcare.util.PicassoImageCompressor
 import com.example.petcare.util.normalizeForCommit
 import com.example.petcare.util.sanitizeForEditing
 import com.example.petcare.util.validateCommittedInput
+import android.widget.Toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -115,7 +116,7 @@ class AddVaccineViewModel : ViewModel() {
             "Queued vaccination staging document petId=$petId stagingId=$stagingId fileName=$fileName mimeType=$mimeType"
         )
 
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.Default) {
             Log.d(TAG, "Staging coroutine started thread=${Thread.currentThread().name}")
             try {
                 if (!isOnline(context)) {
@@ -137,7 +138,7 @@ class AddVaccineViewModel : ViewModel() {
                     return@launch
                 }
 
-                val prepared = async(Dispatchers.IO) {
+                val prepared = async(Dispatchers.Default) {
                     PicassoImageCompressor.prepareImageIfNeeded(context, uri, mimeType, fileName)
                 }.await()
                 Log.d(
@@ -167,6 +168,7 @@ class AddVaccineViewModel : ViewModel() {
                                     }
                                 )
                                 Log.d(TAG, "Staging document UI state updated on ${Thread.currentThread().name}")
+                                Toast.makeText(context.applicationContext, "Attachment uploaded successfully", Toast.LENGTH_SHORT).show()
                             }
                         },
                         onFailure = { e ->
@@ -273,11 +275,6 @@ class AddVaccineViewModel : ViewModel() {
             _state.value = s.copy(error = firstError)
             return
         }
-        if (s.stagedDocuments.any { it.isUploading }) {
-            Log.d(TAG, "submit blocked waitingForUploads count=${s.stagedDocuments.count { it.isUploading }}")
-            _state.value = s.copy(error = "Please wait for documents to finish uploading")
-            return
-        }
         val vaccine = selectedVaccine ?: return
 
         viewModelScope.launch {
@@ -310,7 +307,8 @@ class AddVaccineViewModel : ViewModel() {
                     if (newVaccinationId != null) {
                         val successfulDocs = s.stagedDocuments
                             .filter { it.downloadUrl != null && it.error == null }
-                        Log.d(TAG, "submit attaching stagedDocs=${successfulDocs.size} to vaccinationId=$newVaccinationId")
+                        val stillUploadingDocs = s.stagedDocuments.filter { it.isUploading }
+                        Log.d(TAG, "submit attaching stagedDocs=${successfulDocs.size} stillUploading=${stillUploadingDocs.size} to vaccinationId=$newVaccinationId")
 
                         successfulDocs.forEach { doc ->
                             val localUri = doc.downloadUrl.orEmpty()
@@ -346,6 +344,20 @@ class AddVaccineViewModel : ViewModel() {
                                     }
                                 )
                             }
+                        }
+
+                        // Queue still-uploading docs as pending so they sync when the vaccine is opened
+                        stillUploadingDocs.forEach { doc ->
+                            RepositoryProvider.petRepository.queueVaccinationDocument(
+                                sourceUri = doc.uri,
+                                petId = s.petId,
+                                vaccinationId = newVaccinationId,
+                                fileName = doc.fileName,
+                                mimeType = doc.mimeType
+                            ).fold(
+                                onSuccess = { Log.d(TAG, "submit queued in-flight staged document fileName=${doc.fileName} vaccinationId=$newVaccinationId") },
+                                onFailure = { Log.e(TAG, "submit queue in-flight staged document failed fileName=${doc.fileName}: ${it.message}", it) }
+                            )
                         }
                     }
 

--- a/app/src/main/java/com/example/petcare/ui/screens/addVaccineForm/addVaccineFinal.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/addVaccineForm/addVaccineFinal.kt
@@ -131,6 +131,11 @@ fun AddVaccineFinalForm(
                 isUploading = state.stagedDocuments.any { it.isUploading },
                 onDocumentPicked = { uri, mimeType, fileName ->
                     viewModel.addDocument(context, uri, mimeType, fileName)
+                },
+                onDeleteDocument = { docId ->
+                    state.stagedDocuments
+                        .firstOrNull { it.uri.toString() == docId }
+                        ?.let { viewModel.removeDocument(it) }
                 }
             )
 

--- a/app/src/main/java/com/example/petcare/ui/screens/petprofile/EditPetViewModel.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/petprofile/EditPetViewModel.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.petcare.data.analytics.FeatureExecutionTracker
+import com.example.petcare.data.model.CreateWeightLogRequest
 import com.example.petcare.data.model.UpdatePetRequest
 import com.example.petcare.data.repository.RepositoryProvider
 import com.example.petcare.util.InputFieldPolicy
@@ -30,6 +31,7 @@ data class EditPetState(
     val name: String           = "",
     val breed: String          = "",
     val weight: String         = "",
+    val originalWeight: String = "",
     val color: String          = "",
     val birthDate: String      = "",   // dd/MM/yyyy from DateTextField, or yyyy-MM-dd from API
     val knownAllergies: String = "",
@@ -63,6 +65,7 @@ class EditPetViewModel(application: Application) : AndroidViewModel(application)
             name           = sanitizeForEditing(name, InputFieldPolicy.GENERAL_TEXT, InputTextLimits.PET_NAME).value,
             breed          = sanitizeForEditing(breed, InputFieldPolicy.GENERAL_TEXT, InputTextLimits.BREED).value,
             weight         = sanitizeForEditing(weight, InputFieldPolicy.DECIMAL, InputTextLimits.WEIGHT, 199.0).value,
+            originalWeight = weight,
             color          = sanitizeForEditing(color, InputFieldPolicy.GENERAL_TEXT, InputTextLimits.COLOR).value,
             birthDate      = birthDate,
             knownAllergies = sanitizeForEditing(knownAllergies, InputFieldPolicy.GENERAL_TEXT, InputTextLimits.NOTES).value,
@@ -124,6 +127,17 @@ class EditPetViewModel(application: Application) : AndroidViewModel(application)
                 RepositoryProvider.petRepository.updatePet(petId, request)
             }.fold(
                 onSuccess = {
+                    val newWeight = normalizeForCommit(s.weight, InputFieldPolicy.DECIMAL).trimToNullIfBlank()?.toDoubleOrNull()
+                    val oldWeight = normalizeForCommit(s.originalWeight, InputFieldPolicy.DECIMAL).trimToNullIfBlank()?.toDoubleOrNull()
+                    if (newWeight != null && newWeight != oldWeight) {
+                        viewModelScope.launch {
+                            val today = java.time.LocalDate.now().toString() + "T00:00:00Z"
+                            RepositoryProvider.weightLogRepository.createWeightLog(
+                                petId,
+                                CreateWeightLogRequest(weight = newWeight, loggedAt = today)
+                            )
+                        }
+                    }
                     _state.value = _state.value.copy(isSaving = false, isSaved = true)
                 },
                 onFailure = { e ->

--- a/app/src/main/java/com/example/petcare/ui/screens/petprofile/events/EventDetailsScreen.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/petprofile/events/EventDetailsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.MedicalServices
 import androidx.compose.material3.*
+import android.widget.Toast
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -51,6 +52,13 @@ fun EventDetailsScreen(
 
     LaunchedEffect(uiState.isDeleted) {
         if (uiState.isDeleted) onNavigateBack()
+    }
+
+    LaunchedEffect(uiState.toastMessage) {
+        uiState.toastMessage?.let { msg ->
+            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+            viewModel.clearToast()
+        }
     }
 
     // FIX: separate delete and save dialogs - each one waits for user confirmation before acting
@@ -276,6 +284,9 @@ fun EventDetailsScreen(
                                 addDisabledMessage = "Only one document is allowed for events. Delete the current document to upload another.",
                                 onDocumentPicked = { uri, mimeType, fileName ->
                                     viewModel.addDocument(context, petId, uri, mimeType, fileName)
+                                },
+                                onDeleteDocument = { docId ->
+                                    viewModel.deleteDocument(context, eventId, docId)
                                 }
                             )
 
@@ -346,6 +357,9 @@ fun EventDetailsScreen(
                                 addDisabledMessage = "Only one document is allowed for events. Delete the current document to upload another.",
                                 onDocumentPicked = { uri, mimeType, fileName ->
                                     viewModel.addDocument(context, petId, uri, mimeType, fileName)
+                                },
+                                onDeleteDocument = { docId ->
+                                    viewModel.deleteDocument(context, eventId, docId)
                                 }
                             )
                         }

--- a/app/src/main/java/com/example/petcare/ui/screens/petprofile/events/EventDetailsViewModel.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/petprofile/events/EventDetailsViewModel.kt
@@ -35,6 +35,7 @@ data class EventDetailsUiState(
     val isSaving: Boolean = false,
     val isUploadingDoc: Boolean = false,
     val error: String? = null,
+    val toastMessage: String? = null,
     val isDeleted: Boolean = false,
     val isEditing: Boolean = false,
     val petBirthDateIso: String? = null,
@@ -56,14 +57,6 @@ class EventDetailsViewModel : ViewModel() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
             if (petId.isNotBlank()) {
-                RepositoryProvider.eventRepository.syncPendingEventDocuments(petId, eventId)
-                    .onSuccess { synced ->
-                        if (synced > 0) {
-                            Log.d(TAG, "Synced pending event documents before load count=$synced eventId=$eventId")
-                        }
-                    }
-            }
-            if (petId.isNotBlank()) {
                 RepositoryProvider.petRepository.getPet(petId).onSuccess { pet ->
                     _uiState.value = _uiState.value.copy(petBirthDateIso = pet.birthDate)
                 }
@@ -74,7 +67,9 @@ class EventDetailsViewModel : ViewModel() {
                 onSuccess = { event ->
                     val (appDate, appTime) = EventDateUtils.splitToAppDateTime(event.date)
                     val displayEvent = event.copy(
-                        attachedDocuments = event.attachedDocuments + pendingAttachedDocuments(event.petId, event.id)
+                        attachedDocuments = RepositoryProvider.eventRepository
+                            .filterLocallyDeletedEventDocs(event.petId, event.id, event.attachedDocuments) +
+                            pendingAttachedDocuments(event.petId, event.id)
                     )
                     _uiState.value = _uiState.value.copy(
                         event           = displayEvent,
@@ -87,6 +82,32 @@ class EventDetailsViewModel : ViewModel() {
                         editDate        = appDate,
                         editTime        = appTime
                     )
+                    // Background sync: doesn't block the UI; refreshes doc list when done.
+                    // Use event.id (the resolved server ID) rather than the nav-arg eventId,
+                    // because if the event was created offline the nav arg may still carry the
+                    // old local_ev_ ID while the Hive pending-doc keys already use the server ID.
+                    if (petId.isNotBlank()) {
+                        val resolvedEventId = event.id
+                        launch {
+                            RepositoryProvider.eventRepository.syncPendingEventDocuments(petId, resolvedEventId)
+                                .onSuccess { synced ->
+                                    if (synced > 0) Log.d(TAG, "Background synced pending event docs count=$synced eventId=$resolvedEventId")
+                                }
+                            RepositoryProvider.eventRepository.syncPendingEventDocumentDeletes(petId, resolvedEventId)
+                            RepositoryProvider.eventRepository.syncHiddenEventDocumentDeletes(petId, resolvedEventId)
+                            RepositoryProvider.eventRepository.getEvent(resolvedEventId).onSuccess { fresh ->
+                                withContext(Dispatchers.Main) {
+                                    _uiState.value = _uiState.value.copy(
+                                        event = fresh.copy(
+                                            attachedDocuments = RepositoryProvider.eventRepository
+                                                .filterLocallyDeletedEventDocs(fresh.petId, fresh.id, fresh.attachedDocuments) +
+                                                pendingAttachedDocuments(fresh.petId, fresh.id)
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                    }
                 },
                 onFailure = { e ->
                     _uiState.value = _uiState.value.copy(
@@ -215,6 +236,9 @@ class EventDetailsViewModel : ViewModel() {
         viewModelScope.launch(Dispatchers.Default) {
             Log.d(TAG, "Detail event upload coroutine started thread=${Thread.currentThread().name}")
 
+            // Flush any pending offline deletes before uploading so the server is in the correct state
+            RepositoryProvider.eventRepository.syncPendingEventDocumentDeletes(petId, eventId)
+
             val resolvedMimeType = mimeType ?: context.contentResolver.getType(uri) ?: "application/octet-stream"
             val resolvedFileName = fileName ?: FirebaseDocumentUploader.getFileName(context, uri)
                 ?: "document_${System.currentTimeMillis()}"
@@ -263,7 +287,9 @@ class EventDetailsViewModel : ViewModel() {
                                         withContext(Dispatchers.Main) {
                                             _uiState.value = _uiState.value.copy(
                                                 event = fresh.copy(
-                                                    attachedDocuments = fresh.attachedDocuments + pendingAttachedDocuments(fresh.petId, fresh.id)
+                                                    attachedDocuments = RepositoryProvider.eventRepository
+                                                        .filterLocallyDeletedEventDocs(fresh.petId, fresh.id, fresh.attachedDocuments) +
+                                                        pendingAttachedDocuments(fresh.petId, fresh.id)
                                                 ),
                                                 isUploadingDoc = false,
                                                 error = "Server still has one document for this event. Delete that document first."
@@ -296,7 +322,7 @@ class EventDetailsViewModel : ViewModel() {
         }
     }
 
-    fun deleteDocument(eventId: String, documentId: String) {
+    fun deleteDocument(context: Context, eventId: String, documentId: String) {
         val petId = _uiState.value.event?.petId ?: return
         if (documentId.startsWith("pending_")) {
             val actualId = documentId.removePrefix("pending_")
@@ -306,48 +332,72 @@ class EventDetailsViewModel : ViewModel() {
                     attachedDocuments = _uiState.value.event?.attachedDocuments
                         .orEmpty()
                         .filter { it.id != documentId }
-                )
+                ),
+                toastMessage = "Document deleted successfully"
             )
-            _uiState.value = _uiState.value.copy(
-                error = "Document deleted in offline queue."
-            )
-        } else {
+            return
+        }
+        if (!isOnline(context)) {
             if (documentId.isBlank()) {
-                val docToDelete = _uiState.value.event?.attachedDocuments?.firstOrNull() ?: return
-                viewModelScope.launch {
-                    RepositoryProvider.eventRepository.deleteEventDocumentByContent(
-                        eventId = eventId,
-                        fileName = docToDelete.fileName,
-                        fileUri = docToDelete.fileUri
-                    ).onSuccess { updatedEvent ->
-                        _uiState.value = _uiState.value.copy(
-                            event = updatedEvent,
-                            error = "Document deleted successfully."
-                        )
-                    }.onFailure { e ->
-                        _uiState.value = _uiState.value.copy(
-                            error = e.message ?: "Could not delete document."
-                        )
-                    }
-                }
-                return
+                // Blank-id doc: optimistically remove + queue via hidden-doc mechanism for content-based sync
+                val docToHide = _uiState.value.event?.attachedDocuments?.firstOrNull() ?: return
+                RepositoryProvider.eventRepository.hideEventDocumentLocally(petId, eventId, docToHide.fileName, docToHide.fileUri)
+                _uiState.value = _uiState.value.copy(
+                    event = _uiState.value.event?.copy(
+                        attachedDocuments = _uiState.value.event?.attachedDocuments.orEmpty().drop(1)
+                    ),
+                    toastMessage = "Document deleted successfully"
+                )
+            } else {
+                val filtered = _uiState.value.event?.copy(
+                    attachedDocuments = _uiState.value.event?.attachedDocuments
+                        .orEmpty()
+                        .filter { (it.documentId ?: it.id).orEmpty() != documentId }
+                )
+                _uiState.value = _uiState.value.copy(
+                    event = filtered,
+                    toastMessage = "Document deleted successfully"
+                )
+                RepositoryProvider.eventRepository.queueEventDocumentDelete(petId, eventId, documentId)
             }
+            return
+        }
+        if (documentId.isBlank()) {
+            val docToDelete = _uiState.value.event?.attachedDocuments?.firstOrNull() ?: return
             viewModelScope.launch {
-                RepositoryProvider.eventRepository.deleteEventDocument(eventId, documentId)
-                    .onSuccess { updatedEvent ->
-                        _uiState.value = _uiState.value.copy(
-                            event = updatedEvent,
-                            error = "Document deleted successfully."
-                        )
-                    }
-                    .onFailure { e ->
-                        _uiState.value = _uiState.value.copy(error = e.message)
-                    }
+                RepositoryProvider.eventRepository.deleteEventDocumentByContent(
+                    eventId = eventId,
+                    fileName = docToDelete.fileName,
+                    fileUri = docToDelete.fileUri
+                ).onSuccess { updatedEvent ->
+                    _uiState.value = _uiState.value.copy(
+                        event = updatedEvent,
+                        toastMessage = "Document deleted successfully"
+                    )
+                }.onFailure { e ->
+                    _uiState.value = _uiState.value.copy(
+                        error = e.message ?: "Could not delete document."
+                    )
+                }
             }
+            return
+        }
+        viewModelScope.launch {
+            RepositoryProvider.eventRepository.deleteEventDocument(eventId, documentId)
+                .onSuccess { updatedEvent ->
+                    _uiState.value = _uiState.value.copy(
+                        event = updatedEvent,
+                        toastMessage = "Document deleted successfully"
+                    )
+                }
+                .onFailure { e ->
+                    _uiState.value = _uiState.value.copy(error = e.message)
+                }
         }
     }
 
     fun clearError() { _uiState.value = _uiState.value.copy(error = null) }
+    fun clearToast() { _uiState.value = _uiState.value.copy(toastMessage = null) }
 
     private fun pendingAttachedDocuments(
         petId: String,

--- a/app/src/main/java/com/example/petcare/ui/screens/petprofile/events/EventDetailsViewModel.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/petprofile/events/EventDetailsViewModel.kt
@@ -19,6 +19,7 @@ import com.example.petcare.util.normalizeForCommit
 import com.example.petcare.util.sanitizeForEditing
 import com.example.petcare.util.trimToNullIfBlank
 import com.example.petcare.util.validateCommittedInput
+import android.widget.Toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -202,18 +203,17 @@ class EventDetailsViewModel : ViewModel() {
         fileName: String? = null
     ) {
         val eventId = _uiState.value.event?.id ?: return
+        if (_uiState.value.isUploadingDoc) return
         if (_uiState.value.event?.attachedDocuments.orEmpty().isNotEmpty()) {
             _uiState.value = _uiState.value.copy(
                 error = "Only one document is allowed for events. Delete the current document to upload another."
             )
             return
         }
+        _uiState.value = _uiState.value.copy(isUploadingDoc = true, error = null)
         Log.d(TAG, "Detail event document upload requested petId=$petId eventId=$eventId")
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.Default) {
             Log.d(TAG, "Detail event upload coroutine started thread=${Thread.currentThread().name}")
-            withContext(Dispatchers.Main) {
-                _uiState.value = _uiState.value.copy(isUploadingDoc = true, error = null)
-            }
 
             val resolvedMimeType = mimeType ?: context.contentResolver.getType(uri) ?: "application/octet-stream"
             val resolvedFileName = fileName ?: FirebaseDocumentUploader.getFileName(context, uri)
@@ -225,7 +225,7 @@ class EventDetailsViewModel : ViewModel() {
             }
 
             val prepared = try {
-                async(Dispatchers.IO) {
+                async(Dispatchers.Default) {
                     PicassoImageCompressor.prepareImageIfNeeded(context, uri, resolvedMimeType, resolvedFileName)
                 }.await()
             } catch (e: Exception) {
@@ -252,6 +252,7 @@ class EventDetailsViewModel : ViewModel() {
                                         event = updatedEvent,
                                         isUploadingDoc = false
                                     )
+                                    Toast.makeText(context.applicationContext, "Attachment uploaded successfully", Toast.LENGTH_SHORT).show()
                                 }
                             },
                             onFailure = { e ->

--- a/app/src/main/java/com/example/petcare/ui/screens/petprofile/vaccines/VaccineDetailsScreen.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/petprofile/vaccines/VaccineDetailsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
+import android.widget.Toast
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,6 +56,13 @@ fun VaccineDetailsScreen(
 
     LaunchedEffect(uiState.isDeleted) {
         if (uiState.isDeleted) onNavigateBack()
+    }
+
+    LaunchedEffect(uiState.toastMessage) {
+        uiState.toastMessage?.let { msg ->
+            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+            viewModel.clearToast()
+        }
     }
 
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -192,6 +200,9 @@ fun VaccineDetailsScreen(
                         isUploading      = uiState.isUploadingDoc,
                         onDocumentPicked = { uri, mimeType, fileName ->
                             viewModel.addDocument(context, uri, mimeType, fileName)
+                        },
+                        onDeleteDocument = { docId ->
+                            viewModel.deleteDocument(context, petId, vaccineId, docId)
                         }
                     )
 

--- a/app/src/main/java/com/example/petcare/ui/screens/petprofile/vaccines/VaccineDetailsViewModel.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/petprofile/vaccines/VaccineDetailsViewModel.kt
@@ -35,8 +35,9 @@ data class VaccineDetailsUiState(
     val isLoading: Boolean = false,
     val isDeleting: Boolean = false,
     val isSaving: Boolean = false,
-    val isUploadingDoc: Boolean = false,      // ← NUEVO
+    val isUploadingDoc: Boolean = false,
     val error: String? = null,
+    val toastMessage: String? = null,
     val isDeleted: Boolean = false,
     val isEditing: Boolean = false,
     val editAdministeredBy: String = "",
@@ -54,12 +55,6 @@ class VaccineDetailsViewModel : ViewModel() {
     fun load(petId: String, vaccineId: String) {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, petId = petId, error = null)
-            RepositoryProvider.petRepository.syncPendingVaccinationDocuments(petId, vaccineId)
-                .onSuccess { synced ->
-                    if (synced > 0) {
-                        Log.d(TAG, "Synced pending documents before load count=$synced vaccinationId=$vaccineId")
-                    }
-                }
 
             val catalogMap = RepositoryProvider.petRepository
                 .getVaccineCatalog()
@@ -91,13 +86,15 @@ class VaccineDetailsViewModel : ViewModel() {
                         nextDueDate       = vacc.nextDueDate?.take(10),
                         lotNumber         = vacc.lotNumber.ifBlank { null },
                         status            = status,
-                        attachedDocuments = vacc.attachedDocuments.map { doc ->
-                            AttachedDocument(
-                                id       = doc.id,
-                                fileName = doc.fileName,
-                                fileUri  = doc.fileUri
-                            )
-                        } + pendingAttachedDocuments(pet.id, vacc.id)
+                        attachedDocuments = RepositoryProvider.petRepository
+                            .filterLocallyDeletedVaxDocs(pet.id, vacc.id, vacc.attachedDocuments.map { doc ->
+                                AttachedDocument(
+                                    id         = doc.id,
+                                    documentId = doc.documentId,
+                                    fileName   = doc.fileName,
+                                    fileUri    = doc.fileUri
+                                )
+                            }) + pendingAttachedDocuments(pet.id, vacc.id)
                     )
 
                     _uiState.value = _uiState.value.copy(
@@ -107,6 +104,35 @@ class VaccineDetailsViewModel : ViewModel() {
                         editNextDueDate    = vacc.nextDueDate?.take(10) ?: "",
                         editLotNumber      = sanitizeForEditing(vacc.lotNumber, InputFieldPolicy.GENERAL_TEXT, InputTextLimits.LOT_NUMBER).value
                     )
+
+                    // Background sync: doesn't block the UI; refreshes doc list when done
+                    launch {
+                        RepositoryProvider.petRepository.syncPendingVaccinationDocuments(petId, vaccineId)
+                            .onSuccess { synced ->
+                                if (synced > 0) Log.d(TAG, "Background synced pending vax docs count=$synced vaccinationId=$vaccineId")
+                            }
+                        RepositoryProvider.petRepository.syncPendingVaxDocumentDeletes(petId, vaccineId)
+                        RepositoryProvider.petRepository.getPet(petId).onSuccess { fresh ->
+                            val freshVacc = fresh.vaccinations.find { it.id == vaccineId }
+                            if (freshVacc != null) {
+                                withContext(Dispatchers.Main) {
+                                    _uiState.value = _uiState.value.copy(
+                                        vaccine = _uiState.value.vaccine?.copy(
+                                            attachedDocuments = RepositoryProvider.petRepository
+                                                .filterLocallyDeletedVaxDocs(fresh.id, freshVacc.id, freshVacc.attachedDocuments.map { doc ->
+                                                    AttachedDocument(
+                                                        id         = doc.id,
+                                                        documentId = doc.documentId,
+                                                        fileName   = doc.fileName,
+                                                        fileUri    = doc.fileUri
+                                                    )
+                                                }) + pendingAttachedDocuments(fresh.id, freshVacc.id)
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                    }
                 },
                 onFailure = { e ->
                     _uiState.value = _uiState.value.copy(
@@ -225,6 +251,10 @@ class VaccineDetailsViewModel : ViewModel() {
         Log.d(TAG, "Detail document upload requested petId=$petId vaccinationId=$vaccinationId")
         viewModelScope.launch(Dispatchers.Default) {
             Log.d(TAG, "Detail upload coroutine started thread=${Thread.currentThread().name}")
+
+            // Flush any pending offline deletes before uploading so the server is in the correct state
+            RepositoryProvider.petRepository.syncPendingVaxDocumentDeletes(petId, vaccinationId)
+
             val resolvedMimeType = mimeType ?: context.contentResolver.getType(uri) ?: "application/octet-stream"
             val resolvedFileName = fileName ?: FirebaseDocumentUploader.getFileName(context, uri)
                 ?: "document_${System.currentTimeMillis()}"
@@ -270,9 +300,10 @@ class VaccineDetailsViewModel : ViewModel() {
                                                 ?.attachedDocuments
                                                 ?.map { doc ->
                                                     AttachedDocument(
-                                                        id       = doc.id,
-                                                        fileName = doc.fileName,
-                                                        fileUri  = doc.fileUri
+                                                        id         = doc.id,
+                                                        documentId = doc.documentId,
+                                                        fileName   = doc.fileName,
+                                                        fileUri    = doc.fileUri
                                                     )
                                                 } ?: emptyList()
                                         )
@@ -300,11 +331,36 @@ class VaccineDetailsViewModel : ViewModel() {
         }
     }
 
-    fun deleteDocument(petId: String, vaccinationId: String, documentId: String) {
+    fun deleteDocument(context: Context, petId: String, vaccinationId: String, documentId: String) {
+        if (documentId.startsWith("pending_")) {
+            val actualId = documentId.removePrefix("pending_")
+            RepositoryProvider.petRepository.removePendingVaccinationDocument(petId, vaccinationId, actualId)
+            _uiState.value = _uiState.value.copy(
+                vaccine = _uiState.value.vaccine?.copy(
+                    attachedDocuments = _uiState.value.vaccine?.attachedDocuments
+                        .orEmpty()
+                        .filter { it.id != documentId }
+                ),
+                toastMessage = "Document deleted successfully"
+            )
+            return
+        }
         if (documentId.isBlank()) {
             _uiState.value = _uiState.value.copy(
                 error = "This document cannot be deleted yet because it has no server id."
             )
+            return
+        }
+        if (!isOnline(context)) {
+            _uiState.value = _uiState.value.copy(
+                vaccine = _uiState.value.vaccine?.copy(
+                    attachedDocuments = _uiState.value.vaccine?.attachedDocuments
+                        .orEmpty()
+                        .filter { (it.documentId ?: it.id).orEmpty() != documentId }
+                ),
+                toastMessage = "Document deleted successfully"
+            )
+            RepositoryProvider.petRepository.queueVaccinationDocumentDelete(petId, vaccinationId, documentId)
             return
         }
         viewModelScope.launch {
@@ -314,9 +370,10 @@ class VaccineDetailsViewModel : ViewModel() {
                     _uiState.value = _uiState.value.copy(
                         vaccine = _uiState.value.vaccine?.copy(
                             attachedDocuments = updatedVacc?.attachedDocuments?.map { doc ->
-                                AttachedDocument(id = doc.id, fileName = doc.fileName, fileUri = doc.fileUri)
+                                AttachedDocument(id = doc.id, documentId = doc.documentId, fileName = doc.fileName, fileUri = doc.fileUri)
                             } ?: emptyList()
-                        )
+                        ),
+                        toastMessage = "Document deleted successfully"
                     )
                 }
                 .onFailure { e ->
@@ -326,6 +383,7 @@ class VaccineDetailsViewModel : ViewModel() {
     }
 
     fun clearError() { _uiState.value = _uiState.value.copy(error = null) }
+    fun clearToast() { _uiState.value = _uiState.value.copy(toastMessage = null) }
 
     private fun resolveVaccineName(
         vaccineId: String?,

--- a/app/src/main/java/com/example/petcare/ui/screens/petprofile/vaccines/VaccineDetailsViewModel.kt
+++ b/app/src/main/java/com/example/petcare/ui/screens/petprofile/vaccines/VaccineDetailsViewModel.kt
@@ -20,6 +20,7 @@ import com.example.petcare.util.normalizeForCommit
 import com.example.petcare.util.sanitizeForEditing
 import com.example.petcare.util.trimToNullIfBlank
 import com.example.petcare.util.validateCommittedInput
+import android.widget.Toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -219,13 +220,11 @@ class VaccineDetailsViewModel : ViewModel() {
     ) {
         val petId         = _uiState.value.petId
         val vaccinationId = _uiState.value.vaccine?.id ?: return
+        if (_uiState.value.isUploadingDoc) return
+        _uiState.value = _uiState.value.copy(isUploadingDoc = true, error = null)
         Log.d(TAG, "Detail document upload requested petId=$petId vaccinationId=$vaccinationId")
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.Default) {
             Log.d(TAG, "Detail upload coroutine started thread=${Thread.currentThread().name}")
-            withContext(Dispatchers.Main) {
-                _uiState.value = _uiState.value.copy(isUploadingDoc = true, error = null)
-                Log.d(TAG, "Detail upload UI loading state set on ${Thread.currentThread().name}")
-            }
             val resolvedMimeType = mimeType ?: context.contentResolver.getType(uri) ?: "application/octet-stream"
             val resolvedFileName = fileName ?: FirebaseDocumentUploader.getFileName(context, uri)
                 ?: "document_${System.currentTimeMillis()}"
@@ -236,7 +235,7 @@ class VaccineDetailsViewModel : ViewModel() {
             }
 
             val prepared = try {
-                async(Dispatchers.IO) {
+                async(Dispatchers.Default) {
                     PicassoImageCompressor.prepareImageIfNeeded(context, uri, resolvedMimeType, resolvedFileName)
                 }.await()
             } catch (e: Exception) {
@@ -279,6 +278,7 @@ class VaccineDetailsViewModel : ViewModel() {
                                         )
                                     )
                                     Log.d(TAG, "Detail document UI state updated on ${Thread.currentThread().name}")
+                                    Toast.makeText(context.applicationContext, "Attachment uploaded successfully", Toast.LENGTH_SHORT).show()
                                 }
                             },
                             onFailure = { e ->


### PR DESCRIPTION
Changes:
* Upload docs now is done on the default thread
* toast notifications for document upload and deletion to preserve full marks on vv3
* Creating and editing a pet's weight adds it to the weight log, with the pet creation or edit date as the weight log entry date.
* Better eventual connectivity features for weight log: creating and editing pet offline also add entry to local storage for weight logging
* Delete button for attachments in the creation and edit forms of vaccines and events.
* Fixed bug where an event was deleted while it got synced to the backend in the transition between offline-online network states.
* 